### PR TITLE
Add BloomREST

### DIFF
--- a/data/bloomrest.yml
+++ b/data/bloomrest.yml
@@ -1,0 +1,6 @@
+name:     BloomREST
+url:      https://github.com/assafmo/BloomREST
+db:       Bloom Filtrrs
+api:      Rest
+lang:     Python
+license:  MIT


### PR DESCRIPTION
REST API for Bloom Filters.
This library wraps bloom filters with HTTP.
This uses as a simple and extremely fast DB and cache.