### PR TITLE
Add Eve for mongodb and SQLAlchemy

### DIFF
--- a/data/eve.yml
+++ b/data/eve.yml
@@ -1,0 +1,6 @@
+name:     Eve
+url:      https://github.com/pyeve/eve
+db:       MongoDB and All supported by SQLAlchemy (MySQL, PostgreSQL, SQLite, Oracle, MS SQL, and others)
+api:      REST
+lang:     Python
+license:  BSD License


### PR DESCRIPTION
I recommend Eve, which I am using for providing REST interface for mongodb. It supports most of the feature provided by Mongodb and also many authorization algorithms.