### PR TITLE
feat(GraphQL-compiler): Add GraphQL compiler project file.

### DIFF
--- a/data/graphql-compiler.yml
+++ b/data/graphql-compiler.yml
@@ -1,0 +1,7 @@
+name:     GraphQL compiler
+url:      https://github.com/kensho-technologies/graphql-compiler
+db:       OrientDB / any other database with Gremlin support
+api:      GraphQL
+lang:     Python 2/3
+license:  Apache 2.0
+notes:    Turns GraphQL into a general-purpose graph query language by using custom directives. GraphQL strings go in, database query strings come out -- so it'll work with any web server framework and database client.


### PR DESCRIPTION
I'm adding an entry for the GraphQL compiler project. This is an open-source library that turns GraphQL into a general-purpose graph database query language by adding some custom directives. It is then able to compile any GraphQL query into a single optimized database query, in one of two target languages: Gremlin and OrientDB SQL. It has been rock-solid in our production environment here at Kensho for over 18 months now, and we have many features for it in active development.

We wrote a blog post about it with more details: https://blog.kensho.com/compiled-graphql-as-a-database-query-language-72e106844282