### PR TITLE
Updated Hasura data to show change from AGPL to Apache license.

### DIFF
--- a/data/hasura-graphql-engine
+++ b/data/hasura-graphql-engine
@@ -3,5 +3,5 @@ url:      https://github.com/hasura/graphql-engine
 db:       PostgreSQL
 api:      GraphQL
 lang:     Haskell
-license:  GNU AGPLv3
+license:  Apache 2.0
 notes:    [Official Docker image](https://hub.docker.com/r/hasura/graphql-engine/).


### PR DESCRIPTION
Looks like they switched to Apache 2.0 last year: https://github.com/hasura/graphql-engine/blob/master/LICENSE